### PR TITLE
Release/2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Akamai Log Delivery Service Connector 
 =====================================
 
-Version 2.1 - June 14, 2023
+Version 2.2.3 - February 27, 2024
 
 Introduction
 ------------

--- a/lds_connector/connector.py
+++ b/lds_connector/connector.py
@@ -177,7 +177,6 @@ class Connector:
         timestamp_datetime = timestamp_datetime.replace(tzinfo=timezone.utc)
         return timestamp_datetime
 
-@staticmethod
 def build_connector(config: Config) -> Connector:
     event_handler = None
     if config.splunk is not None:


### PR DESCRIPTION
Bug fixes:

- Remove an erroneous staticmethod annotation that was causing problems for Python 3.8. The method was not a class member, so the annotation added no value.